### PR TITLE
Enable Zip64 encoding of downloaded raster archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq python-gdal python-numpy libhdf5-serial-dev
 install:
-    - pip install -r requirements.txt -r test_requirements.txt -i http://tools.pacificclimate.org/pypiserver/
-    - pip install -i http://tools.pacificclimate.org/pypiserver/ .
+    - pip install -r requirements.txt -r test_requirements.txt -i https://pypi.pacificclimate.org/simple/
+    - pip install -i https://pypi.pacificclimate.org/simple/ .
 script:
     - py.test

--- a/src/pydap/responses/aaigrid/__init__.py
+++ b/src/pydap/responses/aaigrid/__init__.py
@@ -29,7 +29,7 @@ def ziperator(responders):
     '''
     with SpooledTemporaryFile(1024*1024*1024) as f:
         yield 'PK' # Response headers aren't sent until the first chunk of data is sent.  Let's get this repsonse moving!
-        z = ZipFile(f, 'w', ZIP_DEFLATED)
+        z = ZipFile(f, 'w', ZIP_DEFLATED, True)
 
         for name, responder in responders:
             pos = 2 if f.tell() == 0 else f.tell()


### PR DESCRIPTION
Resolves #2 and #3.  Zip64 encoding supports archives of total size greater than 4GB or total number of files greater than 65535. Also includes minor updates to Travis config files.

Docker test server [here](http://142.104.230.42:8082/hydro_model_out/map/).